### PR TITLE
Include clientMsgId in command response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Include clientMsgId in command responses.
+
 1.4.1 - 20-11-2021
 ===================
 * Encode response payload to true object.

--- a/src/core/CTraderConnection.ts
+++ b/src/core/CTraderConnection.ts
@@ -111,6 +111,8 @@ export class CTraderConnection extends EventEmitter {
         const normalizedPayload = JSON.parse(payload.encodeJSON());
 
         if (sentCommand) {
+            normalizedPayload.clientMsgId = clientMsgId;
+
             if (typeof payload.errorCode === "string" || typeof payload.errorCode === "number") {
                 sentCommand.reject(normalizedPayload);
             }


### PR DESCRIPTION
Include the `clientMsgId` of a command in the respective command response.