### PR TITLE
Create events scope

### DIFF
--- a/src/core/protobuf/CTraderProtobufReader.ts
+++ b/src/core/protobuf/CTraderProtobufReader.ts
@@ -131,6 +131,16 @@ export class CTraderProtobufReader {
     }
 
     public getPayloadTypeByName (name: string): number {
-        return this.#names[name].payloadType;
+        return this.#names[name]?.payloadType ?? -1;
+    }
+
+    public getPayloadNameByType (type: number): string {
+        for (const name of Object.keys(this.#names)) {
+            if (this.#names[name].payloadType === type) {
+                return name;
+            }
+        }
+
+        return "";
     }
 }


### PR DESCRIPTION
Accept only payload name when sending commands or listening events.
Automatically resolve commands that have no response payload defined.